### PR TITLE
feat: use comments instead of checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,13 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/merge-schedule-action@v1
+      - uses: gr2m/merge-schedule-action@v2
         with:
           # Merge method to use. Possible values are merge, squash or
           # rebase. Default is merge.
           merge_method: squash
           # Time zone to use. Default is UTC.
           time_zone: 'America/Los_Angeles'
-          # Name for the check. Default is `Merge Schedule`.
-          check_name: 'Scheduled Merge'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,3 @@ inputs:
      Time zone to use. Default is UTC.
     required: false
     default: UTC
-  check_name:
-    description: |-
-     Name for the check. Default is `Merge Schedule`.
-    required: false
-    default: 'Merge Schedule'

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,3 +1,86 @@
+const commentHeader = "<!-- Merge Schedule Pull Request Comment -->";
+
+/**
+ * Get the previous comment on the pull request
+ * @param {import("@octokit/action").Octokit} octokit 
+ * @param {number} pullRequestNumber
+ */
+async function getPreviousComment(octokit, pullRequestNumber) {
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  const prComments = await octokit.paginate(
+    octokit.rest.issues.listComments,
+    {
+      owner,
+      repo,
+      issue_number: pullRequestNumber,
+    },
+    (response) => {
+      return response.data.filter((comment) =>
+        comment.body?.includes(commentHeader)
+      );
+    }
+  );
+  const previousComment = prComments.pop();
+  return previousComment;
+}
+
+/**
+ * Append the comment header to the body
+ * @param {string} body 
+ */
+function bodyWithHeader(body) {
+  return body.endsWith(commentHeader) ? body : `${body}\n${commentHeader}`;
+}
+
+/**
+ * Create a comment on the pull request
+ * @param {import("@octokit/action").Octokit} octokit 
+ * @param {number} pullRequestNumber 
+ * @param {string} body 
+ */
+async function createComment(octokit, pullRequestNumber, body) {
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  return octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pullRequestNumber,
+    body: bodyWithHeader(body),
+  });
+}
+
+/**
+ * Update the comment on the pull request
+ * @param {import("@octokit/action").Octokit} octokit 
+ * @param {number} commentId 
+ * @param {string} body 
+ */
+async function updateComment(octokit, commentId, body) {
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  return octokit.rest.issues.updateComment({
+    owner,
+    repo,
+    comment_id: commentId,
+    body: bodyWithHeader(body),
+  });
+}
+
+/**
+ * Delete the comment on the pull request
+ * @param {import("@octokit/action").Octokit} octokit 
+ * @param {number} commentId 
+ */
+async function deleteComment(octokit, commentId) {
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+  return octokit.rest.issues.deleteComment({
+    owner,
+    repo,
+    comment_id: commentId,
+  });
+}
+
 module.exports = {
-  commentHeader: "<!-- Merge Schedule Pull Request Comment -->",
+  getPreviousComment,
+  createComment,
+  updateComment,
+  deleteComment,
 };

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,0 +1,3 @@
+module.exports = {
+  commentHeader: "<!-- Merge Schedule Pull Request Comment -->",
+};

--- a/lib/handle_pull_request.js
+++ b/lib/handle_pull_request.js
@@ -1,9 +1,18 @@
-module.exports = handlePullRequest;
-
 const core = require("@actions/core");
 const { Octokit } = require("@octokit/action");
-const { commentHeader } = require('./comment');
+const {
+  createComment,
+  deleteComment,
+  getPreviousComment,
+  updateComment,
+} = require("./comment");
 const localeDate = require("./locale_date");
+const {
+  getScheduleDateString,
+  hasScheduleCommand,
+  isFork,
+  isValidDate,
+} = require("./utils");
 
 /**
  * Handle "pull_request" event
@@ -12,92 +21,63 @@ async function handlePullRequest() {
   const octokit = new Octokit();
 
   const eventPayload = require(process.env.GITHUB_EVENT_PATH);
+  const pullRequest = eventPayload.pull_request;
 
   core.info(
-    `Handling pull request ${eventPayload.action} for ${eventPayload.pull_request.html_url}`
+    `Handling pull request ${eventPayload.action} for ${pullRequest.html_url}`
   );
 
-  if (eventPayload.pull_request.state !== "open") {
+  if (pullRequest.state !== "open") {
     core.info(`Pull request already closed, ignoring`);
     return;
   }
 
-  if (eventPayload.pull_request.head.repo.fork) {
+  if (isFork(pullRequest)) {
     core.setFailed(`Setting a scheduled merge is not allowed from forks`);
     process.exit(1);
   }
 
-  const prComments = await octokit.paginate(
-    octokit.rest.issues.listComments,
-    {
-      owner: eventPayload.repository.owner.login,
-      repo: eventPayload.repository.name,
-      issue_number: eventPayload.pull_request.number,
-    },
-    (response) => {
-      return response.data.filter((comment) =>
-        comment.body?.includes(commentHeader)
-      );
-    }
+  const previousComment = await getPreviousComment(
+    octokit,
+    pullRequest.number
   );
-  const previousComment = prComments.pop();
-  const commentPayload = {
-    owner: eventPayload.repository.owner.login,
-    repo: eventPayload.repository.name,
-    body: `Scheduled to be merged on ${datestring}.`,
-  };
+  const commentBody = `Scheduled to be merged on ${datestring}.`;
 
-  if (!hasScheduleCommand(eventPayload.pull_request.body)) {
+  if (!hasScheduleCommand(pullRequest.body)) {
     if (previousComment) {
-      await octokit.rest.issues.deleteComment({
-        owner: commentPayload.owner,
-        repo: commentPayload.repo,
-        comment_id: previousComment.id,
-      });
+      await deleteComment(octokit, previousComment.id);
     }
     core.info(`No /schedule command found`);
     return;
   }
 
-  const datestring = getScheduleDateString(eventPayload.pull_request.body);
+  const datestring = getScheduleDateString(pullRequest.body);
   core.info(`Schedule date found: "${datestring}"`);
 
   if (!isValidDate(datestring)) {
-    commentPayload.body = `"${datestring}" is not a valid date.`;
+    commentBody = `"${datestring}" is not a valid date.`;
   }
 
   if (new Date(datestring) < localeDate()) {
-    commentPayload.body = `"${datestring}" is already in the past.`;
+    commentBody = `"${datestring}" is already in the past.`;
   }
 
-  commentPayload.body = `${commentPayload.body}\n${commentHeader}`;
-
   if (previousComment) {
-    const { data } = await octokit.rest.issues.updateComment({
-      ...commentPayload,
-      comment_id: previousComment.id,
-    });
+    const { data } = await updateComment(
+      octokit,
+      previousComment.id,
+      commentBody
+    );
     core.info(`Comment updated: ${data.html_url}`);
     return;
   }
 
-  const { data } = await octokit.rest.issues.createComment({
-    ...commentPayload,
-    issue_number: eventPayload.pull_request.number,
-  });
+  const { data } = await createComment(
+    octokit,
+    pullRequest.number,
+    commentBody
+  );
   core.info(`Comment created: ${data.html_url}`);
 }
 
-function hasScheduleCommand(text) {
-  return /(^|\n)\/schedule /.test(text);
-}
-
-function getScheduleDateString(text) {
-  return text.match(/(^|\n)\/schedule (.*)/).pop();
-}
-
-// https://stackoverflow.com/a/1353711/206879
-function isValidDate(datestring) {
-  const date = new Date(datestring);
-  return date instanceof Date && !Number.isNaN(date);
-}
+module.exports = handlePullRequest;

--- a/lib/handle_pull_request.js
+++ b/lib/handle_pull_request.js
@@ -2,6 +2,7 @@ module.exports = handlePullRequest;
 
 const core = require("@actions/core");
 const { Octokit } = require("@octokit/action");
+const { commentHeader } = require('./comment');
 const localeDate = require("./locale_date");
 
 /**
@@ -11,7 +12,6 @@ async function handlePullRequest() {
   const octokit = new Octokit();
 
   const eventPayload = require(process.env.GITHUB_EVENT_PATH);
-  const checkName = process.env.INPUT_CHECK_NAME;
 
   core.info(
     `Handling pull request ${eventPayload.action} for ${eventPayload.pull_request.html_url}`
@@ -27,7 +27,34 @@ async function handlePullRequest() {
     process.exit(1);
   }
 
+  const prComments = await octokit.paginate(
+    octokit.rest.issues.listComments,
+    {
+      owner: eventPayload.repository.owner.login,
+      repo: eventPayload.repository.name,
+      issue_number: eventPayload.pull_request.number,
+    },
+    (response) => {
+      return response.data.filter((comment) =>
+        comment.body?.includes(commentHeader)
+      );
+    }
+  );
+  const previousComment = prComments.pop();
+  const commentPayload = {
+    owner: eventPayload.repository.owner.login,
+    repo: eventPayload.repository.name,
+    body: `Scheduled to be merged on ${datestring}.`,
+  };
+
   if (!hasScheduleCommand(eventPayload.pull_request.body)) {
+    if (previousComment) {
+      await octokit.rest.issues.deleteComment({
+        owner: commentPayload.owner,
+        repo: commentPayload.repo,
+        comment_id: previousComment.id,
+      });
+    }
     core.info(`No /schedule command found`);
     return;
   }
@@ -36,49 +63,29 @@ async function handlePullRequest() {
   core.info(`Schedule date found: "${datestring}"`);
 
   if (!isValidDate(datestring)) {
-    const { data } = await octokit.checks.create({
-      owner: eventPayload.repository.owner.login,
-      repo: eventPayload.repository.name,
-      name: checkName,
-      head_sha: eventPayload.pull_request.head.sha,
-      conclusion: "failure",
-      output: {
-        title: `"${datestring}" is not a valid date`,
-        summary: "",
-      },
-    });
-    core.info(`Check run created: ${data.html_url}`);
-    return;
+    commentPayload.body = `"${datestring}" is not a valid date.`;
   }
 
   if (new Date(datestring) < localeDate()) {
-    const { data } = await octokit.checks.create({
-      owner: eventPayload.repository.owner.login,
-      repo: eventPayload.repository.name,
-      name: checkName,
-      head_sha: eventPayload.pull_request.head.sha,
-      conclusion: "failure",
-      output: {
-        title: `"${datestring}" is already in the past`,
-        summary: "",
-      },
+    commentPayload.body = `"${datestring}" is already in the past.`;
+  }
+
+  commentPayload.body = `${commentPayload.body}\n${commentHeader}`;
+
+  if (previousComment) {
+    const { data } = await octokit.rest.issues.updateComment({
+      ...commentPayload,
+      comment_id: previousComment.id,
     });
-    core.info(`Check run created: ${data.html_url}`);
+    core.info(`Comment updated: ${data.html_url}`);
     return;
   }
 
-  const { data } = await octokit.checks.create({
-    owner: eventPayload.repository.owner.login,
-    repo: eventPayload.repository.name,
-    name: checkName,
-    head_sha: eventPayload.pull_request.head.sha,
-    status: "in_progress",
-    output: {
-      title: `Scheduled to be merged on ${datestring}`,
-      summary: "",
-    },
+  const { data } = await octokit.rest.issues.createComment({
+    ...commentPayload,
+    issue_number: eventPayload.pull_request.number,
   });
-  core.info(`Check run created: ${data.html_url}`);
+  core.info(`Comment created: ${data.html_url}`);
 }
 
 function hasScheduleCommand(text) {

--- a/lib/handle_schedule.js
+++ b/lib/handle_schedule.js
@@ -1,9 +1,8 @@
-module.exports = handleSchedule;
-
 const core = require("@actions/core");
 const { Octokit } = require("@octokit/action");
-const { commentHeader } = require("./comment");
+const { getPreviousComment, updateComment } = require("./comment");
 const localeDate = require("./locale_date");
+const { getScheduleDateString, hasScheduleCommand, isFork } = require("./utils");
 
 /**
  * handle "schedule" event
@@ -24,8 +23,8 @@ async function handleSchedule() {
     },
     (response) => {
       return response.data
-        .filter((pullRequest) => hasScheduleCommand(pullRequest))
-        .filter((pullRequest) => isntFromFork(pullRequest))
+        .filter((pullRequest) => hasScheduleCommand(pullRequest.body))
+        .filter((pullRequest) => !isFork(pullRequest))
         .map((pullRequest) => {
           return {
             number: pullRequest.number,
@@ -61,43 +60,21 @@ async function handleSchedule() {
       pull_number: pullRequest.number,
       merge_method: mergeMethod,
     });
+    core.info(`${pullRequest.html_url} merged`);
 
-    const prComments = await octokit.paginate(
-      octokit.rest.issues.listComments,
-      {
-        owner,
-        repo,
-        issue_number: pullRequest.number,
-      },
-      (response) => {
-        return response.data.filter((comment) =>
-          comment.body?.includes(commentHeader)
-        );
-      }
+    const previousComment = await getPreviousComment(
+      octokit,
+      pullRequest.number
     );
-    const previousComment = prComments.pop();
     if (previousComment) {
-      const { data } = await octokit.rest.issues.updateComment({
-        owner,
-        repo,
-        comment_id: previousComment.id,
-        body: `Scheduled on ${pullRequest.scheduledDate} successfully merged.\n${commentHeader}`,
-      });
+      const { data } = await updateComment(
+        octokit,
+        previousComment.id,
+        `Scheduled on ${pullRequest.scheduledDate} successfully merged.`
+      );
       core.info(`Comment updated: ${data.html_url}`);
     }
-
-    core.info(`${pullRequest.html_url} merged`);
   }
 }
 
-function hasScheduleCommand(pullRequest) {
-  return /(^|\n)\/schedule /.test(pullRequest.body);
-}
-
-function isntFromFork(pullRequest) {
-  return !pullRequest.head.repo.fork;
-}
-
-function getScheduleDateString(text) {
-  return text.match(/(^|\n)\/schedule (.*)/).pop();
-}
+module.exports = handleSchedule;

--- a/lib/handle_schedule.js
+++ b/lib/handle_schedule.js
@@ -2,6 +2,7 @@ module.exports = handleSchedule;
 
 const core = require("@actions/core");
 const { Octokit } = require("@octokit/action");
+const { commentHeader } = require("./comment");
 const localeDate = require("./locale_date");
 
 /**
@@ -12,11 +13,10 @@ async function handleSchedule() {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
 
   const mergeMethod = process.env.INPUT_MERGE_METHOD;
-  const checkName = process.env.INPUT_CHECK_NAME;
 
   core.info(`Loading open pull request`);
   const pullRequests = await octokit.paginate(
-    "GET /repos/:owner/:repo/pulls",
+    octokit.pulls.list,
     {
       owner,
       repo,
@@ -62,33 +62,28 @@ async function handleSchedule() {
       merge_method: mergeMethod,
     });
 
-    // find check runs by the Merge schedule action
-    const checkRuns = await octokit.paginate(
-      octokit.checks.listForRef,
+    const prComments = await octokit.paginate(
+      octokit.rest.issues.listComments,
       {
         owner,
         repo,
-        ref: pullRequest.ref,
+        issue_number: pullRequest.number,
       },
       (response) => {
-        return response.data.filter((check) => check.name === checkName);
+        return response.data.filter((comment) =>
+          comment.body?.includes(commentHeader)
+        );
       }
     );
-
-    const checkRun = checkRuns.pop();
-    if (checkRun) {
-      await octokit.checks.update({
-        check_run_id: checkRun.id,
+    const previousComment = prComments.pop();
+    if (previousComment) {
+      const { data } = await octokit.rest.issues.updateComment({
         owner,
         repo,
-        name: checkName,
-        head_sha: pullRequest.headSha,
-        conclusion: "success",
-        output: {
-          title: `Scheduled on ${pullRequest.scheduledDate}`,
-          summary: "Merged successfully",
-        },
+        comment_id: previousComment.id,
+        body: `Scheduled on ${pullRequest.scheduledDate} successfully merged.\n${commentHeader}`,
       });
+      core.info(`Comment updated: ${data.html_url}`);
     }
 
     core.info(`${pullRequest.html_url} merged`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,39 @@
+/**
+ * Check if the given string is a schedule command.
+ * @param {string} text The text to check.
+ */
+function hasScheduleCommand(text) {
+  return /(^|\n)\/schedule /.test(text);
+}
+
+/**
+ * Get the date string from the schedule command.
+ * @param {string} text The text to match.
+ */
+function getScheduleDateString(text) {
+  return text.match(/(^|\n)\/schedule (.*)/).pop();
+}
+
+/**
+ * Check if the given string is a valid date.
+ * @reference https://stackoverflow.com/a/1353711/206879
+ */
+function isValidDate(datestring) {
+  const date = new Date(datestring);
+  return date instanceof Date && !Number.isNaN(date);
+}
+
+/**
+ * Check if pull request is a fork.
+ * @param {*} pullRequest 
+ */
+function isFork(pullRequest) {
+  return Boolean(pullRequest.head.repo.fork);
+}
+
+module.exports = {
+  hasScheduleCommand,
+  getScheduleDateString,
+  isFork,
+  isValidDate,
+}


### PR DESCRIPTION
BREAKING CHANGE: checks are no longer used in favor of comments

When using the `GITHUB_TOKEN` to authenticate actions, no workflows will run after pull requests get merged.

To trigger workflow runs, a [Private Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) should be used to authenticate with an account other than the one behind the `GITHUB_TOKEN` token.

Checks can only be created by `GITHUB_TOKEN` or GitHub Apps, so a Private Access Token won't work.

To overcome this limitation, using comments in place of checks to provide feedback on the pull request is a simple solution done on this pull request.