### PR TITLE
fix: invalid date logic

### DIFF
--- a/lib/handle_pull_request.js
+++ b/lib/handle_pull_request.js
@@ -92,5 +92,5 @@ function getScheduleDateString(text) {
 // https://stackoverflow.com/a/1353711/206879
 function isValidDate(datestring) {
   const date = new Date(datestring);
-  return date instanceof Date && !Number.isNaN(date);
+  return date instanceof Date && !isNaN(date);
 }


### PR DESCRIPTION
I just noticed the logic for checking invalid dates is broken.

This was my fault when I changed `isNaN` to `Number.isNAN` in this [pull request](https://github.com/gr2m/merge-schedule-action/pull/56/files#diff-db5f30fef77b50c1b0cd73b17aa7a84ef4df178a14cee2f4198eca7077dc3c76L94).