### PR TITLE
fix: allow merging commits with no statuses

### DIFF
--- a/lib/commit.ts
+++ b/lib/commit.ts
@@ -32,5 +32,8 @@ export async function getCommitStatusesStatus(
     ref: commitRef,
   });
 
+  if (data.statuses === undefined || data.statuses.length === 0)
+    return "success";
+
   return data.state as "success" | "pending" | "failure";
 }

--- a/lib/handle-schedule.test.ts
+++ b/lib/handle-schedule.test.ts
@@ -33,8 +33,8 @@ describe("handleSchedule", () => {
 
     expect(mockStdout.mock.calls).toEqual([
       [`Loading open pull requests\n`],
-      [`6 scheduled pull requests found\n`],
-      [`5 due pull requests found\n`],
+      [`7 scheduled pull requests found\n`],
+      [`6 due pull requests found\n`],
       [`https://github.com/gr2m/merge-schedule-action/pull/2 merged\n`],
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/2#issuecomment-22\n`,
@@ -55,8 +55,12 @@ describe("handleSchedule", () => {
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/7#issuecomment-72\n`,
       ],
+      [`https://github.com/gr2m/merge-schedule-action/pull/14 merged\n`],
+      [
+        `Comment created: https://github.com/gr2m/merge-schedule-action/issues/14#issuecomment-142\n`,
+      ],
     ]);
-    expect(createComment.mock.calls).toHaveLength(3);
+    expect(createComment.mock.calls).toHaveLength(4);
     expect(createComment.mock.calls[0][2]).toMatchInlineSnapshot(`
       ":white_check_mark: **Merge Schedule**
       Scheduled on 2022-06-08 (UTC) successfully merged
@@ -97,8 +101,8 @@ describe("handleSchedule", () => {
 
     expect(mockStdout.mock.calls).toEqual([
       [`Loading open pull requests\n`],
-      [`6 scheduled pull requests found\n`],
-      [`5 due pull requests found\n`],
+      [`7 scheduled pull requests found\n`],
+      [`6 due pull requests found\n`],
       [`https://github.com/gr2m/merge-schedule-action/pull/2 merged\n`],
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/2#issuecomment-22\n`,
@@ -118,8 +122,12 @@ describe("handleSchedule", () => {
       [
         `Comment created: https://github.com/gr2m/merge-schedule-action/issues/7#issuecomment-72\n`,
       ],
+      [`https://github.com/gr2m/merge-schedule-action/pull/14 merged\n`],
+      [
+        `Comment created: https://github.com/gr2m/merge-schedule-action/issues/14#issuecomment-142\n`,
+      ],
     ]);
-    expect(createComment.mock.calls).toHaveLength(3);
+    expect(createComment.mock.calls).toHaveLength(4);
     expect(createComment.mock.calls[0][2]).toMatchInlineSnapshot(`
       ":white_check_mark: **Merge Schedule**
       Scheduled on 2022-06-08 (UTC) successfully merged

--- a/test/mocks/github.ts
+++ b/test/mocks/github.ts
@@ -122,6 +122,19 @@ const pullRequests = [
     },
     labels: [],
   },
+  {
+    number: 14,
+    html_url: githubPullRequestUrl(14),
+    state: "open",
+    body: "Simple body\n/schedule 2022-06-09",
+    head: {
+      sha: "abc123pending-empty",
+      repo: {
+        fork: false,
+      },
+    },
+    labels: [],
+  },
 ];
 const pullRequestComments = pullRequests.map((pullRequest) => {
   let body = "";
@@ -258,7 +271,7 @@ export const githubHandlers = [
         ctx.status(200),
         ctx.json({
           state: req.params.ref.endsWith("success") ? "success" : "pending",
-          statuses: [],
+          statuses: req.params.ref.endsWith("pending-empty") ? [] : ["pending"],
         })
       );
     }


### PR DESCRIPTION
Fixes https://github.com/gr2m/merge-schedule-action/issues/82

- When no statuses are set for a commit, github api returns combined status "pending" even if all check-runs etc are completed. Requiring a hard "success" will never pass in this configuration...
- If no statuses are set, none should be expected, and so they can be treated as "success" regardless