### PR TITLE
fix: bump runner to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: "git-merge"
   color: purple
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 inputs:
   merge_method:


### PR DESCRIPTION
Node 16 GA actions are deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/