### PR TITLE
Add npm build step to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test:ci
+      - run: npm run build
       - run: npm install --no-save @semantic-release/git semantic-release-plugin-github-breaking-version-tag
       - run: npx semantic-release --debug
         env:


### PR DESCRIPTION
The build step was removed from the release action in https://github.com/gr2m/merge-schedule-action/commit/a7fc2f28bf3c21964fdd58bbfeb3daaf886df969. Since this Commit releases only contained updates, if a previously merged PR updated `dist/index.js`. This also affects [v2.6.1](https://github.com/gr2m/merge-schedule-action/releases/tag/v2.6.1) and [v2.6.2](https://github.com/gr2m/merge-schedule-action/releases/tag/v2.6.2), so current changes are effectively unreleased.

To prevent that we should add the build steps again to the release pipeline.

I checked if this can be handeld by [semantic-release](https://github.com/semantic-release/semantic-release) but the docs state:

> semantic-release is meant to be executed on the CI environment after every successful build on the release branch.

So I believe the build steps were deleted by accident.

closes #94 