### PR TITLE
respect expicit timezone on schedule command

### DIFF
--- a/lib/handle-pull-request.ts
+++ b/lib/handle-pull-request.ts
@@ -8,6 +8,7 @@ import type {
 } from "@octokit/webhooks-types";
 import {
   getScheduleDateString,
+  hasExplicitTimeZone,
   hasScheduleCommand,
   isFork,
   isValidDate,
@@ -76,7 +77,10 @@ export default async function handlePullRequest(): Promise<void> {
         `"${datestring}" is not a valid date`,
         "error"
       );
-    } else if (new Date(datestring) < localeDate()) {
+    } else if (
+      new Date(datestring) <
+      (hasExplicitTimeZone(datestring) ? new Date() : localeDate())
+    ) {
       let message = `${stringifyDate(datestring)} (UTC) is already in the past`;
       if (process.env.INPUT_TIME_ZONE !== "UTC") {
         message = `${message} on ${process.env.INPUT_TIME_ZONE} time zone`;

--- a/lib/handle-schedule.ts
+++ b/lib/handle-schedule.ts
@@ -11,6 +11,7 @@ import localeDate from "./locale-date";
 import { getCommitChecksRunsStatus, getCommitStatusesStatus } from "./commit";
 import {
   getScheduleDateString,
+  hasExplicitTimeZone,
   hasScheduleCommand,
   isFork,
   isValidMergeMethod,
@@ -70,11 +71,13 @@ export default async function handleSchedule(): Promise<void> {
     return;
   }
 
-  const duePullRequests = pullRequests.filter(
-    (pullRequest) =>
-      pullRequest.scheduledDate === "" ||
-      new Date(pullRequest.scheduledDate) < localeDate()
-  );
+  const duePullRequests = pullRequests.filter((pullRequest) => {
+    if (pullRequest.scheduledDate === "") return true;
+    const now = hasExplicitTimeZone(pullRequest.scheduledDate)
+      ? new Date()
+      : localeDate();
+    return new Date(pullRequest.scheduledDate) < now;
+  });
 
   core.info(`${duePullRequests.length} due pull requests found`);
 

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -2,6 +2,7 @@ import timezoneMock from "timezone-mock";
 import { test, expect } from "vitest";
 import {
   getScheduleDateString,
+  hasExplicitTimeZone,
   hasScheduleCommand,
   isValidMergeMethod,
   isValidDate,
@@ -53,4 +54,15 @@ test("stringifyDate", () => {
   expect(stringifyDate("2022-06-08")).toBe("2022-06-08 00:00:00");
   expect(stringifyDate("2022-06-08T09:00:00")).toBe("2022-06-08 09:00:00");
   expect(stringifyDate("2022-06-08T15:00:00Z")).toBe("2022-06-08 15:00:00");
+});
+
+test("hasExplicitTimeZone", () => {
+  expect(hasExplicitTimeZone("2022-06-08")).toBe(false);
+  expect(hasExplicitTimeZone("2022-06-08T09:00:00")).toBe(false);
+  expect(hasExplicitTimeZone("2022-06-08T15:00:00Z")).toBe(true);
+  expect(hasExplicitTimeZone("2022-06-08T15:00:00z")).toBe(true);
+  expect(hasExplicitTimeZone("2022-06-08T15:00:00.000Z")).toBe(true);
+  expect(hasExplicitTimeZone("2022-06-08T12:00:00-04:00")).toBe(true);
+  expect(hasExplicitTimeZone("2022-06-08T12:00:00+05:30")).toBe(true);
+  expect(hasExplicitTimeZone("2022-06-08T12:00:00-0400")).toBe(true);
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -33,3 +33,10 @@ export function stringifyDate(datestring: string): string {
   const [date, time] = dateTimeString.split("T");
   return `${date} ${time}`;
 }
+
+// True if the string ends with `Z` or `±HH:MM`/`±HHMM`. Such strings are
+// absolute instants and must be compared against the real current time —
+// not the wall-clock value localeDate() returns for the configured TZ.
+export function hasExplicitTimeZone(datestring: string): boolean {
+  return /([zZ]|[+-]\d{2}:?\d{2})$/.test(datestring);
+}


### PR DESCRIPTION
Hey there, thought I'd open up a PR to solve an issue I had with explicit timestamps.

Now, when a `/schedule` command includes an explicit timezone offset (e.g. `2026-05-21T12:00:00-04:00` or a `Z` suffix), the scheduled date is now compared against the real current time instead of `localeDate()`'s wall-clock value for `INPUT_TIME_ZONE`.

Before, both the "in the past" validation in `handle-pull-request` and the due-PR filter in `handle-schedule` always compared against `localeDate()`, which returns a `Date` whose UTC fields are shifted to match the configured timezone's wall clock (in the `yaml` file).

  ## Changes
  - Add `hasExplicitTimeZone(datestring)` in `lib/utils.ts` — detects trailing `Z` or `±HH:MM`/`±HHMM` offsets.
  - `lib/handle-pull-request.ts`: use `new Date()` instead of `localeDate()` when the scheduled string carries an explicit offset.
  - `lib/handle-schedule.ts`: same treatment when filtering due PRs.
  - `lib/utils.test.ts`: cover bare dates, naive datetimes, `Z`/`z`, fractional seconds, and `±HH:MM` / `±HHMM` offsets.

  ## Testing
  - [ ] `npm test` — new `hasExplicitTimeZone` cases pass
  - [ ] Schedule a PR with `Z` suffix under a non-UTC `INPUT_TIME_ZONE` and confirm it isn't flagged as past prematurely
  - [ ] Schedule a PR with a naive datetime and confirm existing TZ-aware behavior is unchanged